### PR TITLE
feat: hardhat-interact enhanced for accounts

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -8,6 +8,7 @@ import "hardhat-gas-reporter";
 import "solidity-coverage";
 import "hardhat-deploy";
 import "hardhat-deploy-ethers";
+import "hardhat-interact";
 
 dotenv.config();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "hardhat-deploy": "^0.11.11",
-        "hardhat-deploy-ethers": "^0.3.0-beta.13"
+        "hardhat-deploy-ethers": "^0.3.0-beta.13",
+        "hardhat-interact": "github:JChiaramonte7/hardhat-interact#master-build"
       },
       "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.0.5",
@@ -1424,7 +1425,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.5.tgz",
       "integrity": "sha512-A2gZAGB6kUvLx+kzM92HKuUF33F1FSe90L0TmkXkT2Hh0OKRpvWZURUSU2nghD2yC4DzfEZ3DftfeHGvZ2JTUw==",
-      "dev": true,
       "peerDependencies": {
         "ethers": "^5.0.0",
         "hardhat": "^2.0.0"
@@ -1706,6 +1706,15 @@
       "integrity": "sha512-eLjj2L6AuQjBB6s/ibwCAc0DwrR5Ge+ys+wgWo+bviU7fV2nTMQhU63CGaDKXg9iTmMxwhkyoggdIR7ZGRfMgw==",
       "dependencies": {
         "antlr4ts": "^0.5.0-alpha.4"
+      }
+    },
+    "node_modules/@synthetixio/wei": {
+      "version": "2.74.1",
+      "resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
+      "integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
+      "dependencies": {
+        "big.js": "^6.1.1",
+        "ethers": "^5.5.3"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -2806,6 +2815,18 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
+    "node_modules/big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.0.2",
@@ -16783,6 +16804,95 @@
         "hardhat": "^2.0.2"
       }
     },
+    "node_modules/hardhat-interact": {
+      "version": "0.2.2",
+      "resolved": "git+ssh://git@github.com/JChiaramonte7/hardhat-interact.git#6f0f767f70e8099f72d3948ea88abb3807cefbd5",
+      "license": "MIT",
+      "dependencies": {
+        "@synthetixio/wei": "^2.53.0-alpha2",
+        "axios": "^0.24.0",
+        "chalk": "^4.0.0",
+        "ethers": "^5.5.1",
+        "lodash": "^4.17.21",
+        "prompts": "^2.4.2"
+      },
+      "peerDependencies": {
+        "@nomiclabs/hardhat-ethers": "^2.0.0",
+        "hardhat": "^2.0.0"
+      }
+    },
+    "node_modules/hardhat-interact/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/hardhat-interact/node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
+    "node_modules/hardhat-interact/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/hardhat-interact/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/hardhat-interact/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/hardhat-interact/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat-interact/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -17869,6 +17979,14 @@
       "dev": true,
       "dependencies": {
         "graceful-fs": "^4.1.11"
+      }
+    },
+    "node_modules/kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/lcid": {
@@ -19642,6 +19760,18 @@
         "asap": "~2.0.6"
       }
     },
+    "node_modules/prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "dependencies": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -20627,6 +20757,11 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "node_modules/sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -24541,7 +24676,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.5.tgz",
       "integrity": "sha512-A2gZAGB6kUvLx+kzM92HKuUF33F1FSe90L0TmkXkT2Hh0OKRpvWZURUSU2nghD2yC4DzfEZ3DftfeHGvZ2JTUw==",
-      "dev": true,
       "requires": {}
     },
     "@nomiclabs/hardhat-etherscan": {
@@ -24777,6 +24911,15 @@
       "integrity": "sha512-eLjj2L6AuQjBB6s/ibwCAc0DwrR5Ge+ys+wgWo+bviU7fV2nTMQhU63CGaDKXg9iTmMxwhkyoggdIR7ZGRfMgw==",
       "requires": {
         "antlr4ts": "^0.5.0-alpha.4"
+      }
+    },
+    "@synthetixio/wei": {
+      "version": "2.74.1",
+      "resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.1.tgz",
+      "integrity": "sha512-YhiEtumbO0o9cwQmoTaqfyDURUTp4s7ujcpESlHJ3fN0W4SLFkZPM3omv2A3vzTXDiIDJnOK7t6PXYuLfFS1sg==",
+      "requires": {
+        "big.js": "^6.1.1",
+        "ethers": "^5.5.3"
       }
     },
     "@szmarczak/http-timer": {
@@ -25659,6 +25802,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/bech32/-/bech32-1.1.4.tgz",
       "integrity": "sha512-s0IrSOzLlbvX7yp4WBfPITzpAU8sqQcpsmwXDiKwrG4r491vwCO/XpejasRNl0piBMe/DvP4Tz0mIS/X1DPJBQ=="
+    },
+    "big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ=="
     },
     "bignumber.js": {
       "version": "9.0.2",
@@ -36363,6 +36511,71 @@
         "sha1": "^1.1.1"
       }
     },
+    "hardhat-interact": {
+      "version": "git+ssh://git@github.com/JChiaramonte7/hardhat-interact.git#6f0f767f70e8099f72d3948ea88abb3807cefbd5",
+      "from": "hardhat-interact@https://github.com/JChiaramonte7/hardhat-interact/tree/master-build",
+      "requires": {
+        "@synthetixio/wei": "^2.53.0-alpha2",
+        "axios": "^0.24.0",
+        "chalk": "^4.0.0",
+        "ethers": "^5.5.1",
+        "lodash": "^4.17.21",
+        "prompts": "^2.4.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "axios": {
+          "version": "0.24.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
+    },
     "has": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -37161,6 +37374,11 @@
       "requires": {
         "graceful-fs": "^4.1.11"
       }
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
     "lcid": {
       "version": "1.0.0",
@@ -38515,6 +38733,15 @@
         "asap": "~2.0.6"
       }
     },
+    "prompts": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
+      "integrity": "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==",
+      "requires": {
+        "kleur": "^3.0.3",
+        "sisteransi": "^1.0.5"
+      }
+    },
     "proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -39268,6 +39495,11 @@
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
+    },
+    "sisteransi": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
+      "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "hardhat-deploy": "^0.11.11",
-    "hardhat-deploy-ethers": "^0.3.0-beta.13"
+    "hardhat-deploy-ethers": "^0.3.0-beta.13",
+    "hardhat-interact": "github:JChiaramonte7/hardhat-interact#master-build"
   }
 }


### PR DESCRIPTION
- Adds an enhanced version of hardhat-interact that allows you to target specific addresses with an ABI file.

This is useful for interacting with accounts created from the factory.


### Usage
Format
```
npx hardhat interact <ADDRESS> <PATH_TO_ABI_FILE>
```
Example
```
npx hardhat --network optimistic-kovan interact 0xa631feb82C43105d21bB7cd64aDD195614032a33 ./artifacts/MarginBase.sol/MarginBase.json
```

### Result
<img width="572" alt="image" src="https://user-images.githubusercontent.com/4015977/179833138-a1a00101-828d-485c-9d42-277e5fff3162.png">
