### PR TITLE
feat: implement stop orders

### DIFF
--- a/contracts/interfaces/IMarginBase.sol
+++ b/contracts/interfaces/IMarginBase.sol
@@ -29,7 +29,7 @@ interface IMarginBase is IMarginBaseTypes {
 
     // Limit Orders
     function validOrder(uint256 _orderId) external view returns (bool);
-    function placeOrder(bytes32 _marketKey, int256 _marginDelta, int256 _sizeDelta, uint256 _limitPrice) external payable returns (uint256);
+    function placeOrder(bytes32 _marketKey, int256 _marginDelta, int256 _sizeDelta, uint256 _targetPrice, OrderTypes _orderType) external payable returns (uint256);
     function cancelOrder(uint256 _orderId) external;
     function checker(uint256 _orderId) external view returns (bool canExec, bytes memory execPayload);
 

--- a/contracts/interfaces/IMarginBaseTypes.sol
+++ b/contracts/interfaces/IMarginBaseTypes.sol
@@ -9,6 +9,13 @@ interface IMarginBaseTypes {
                                 Types
     ///////////////////////////////////////////////////////////////*/
 
+    // denotes order types for code clarity
+    /// @dev under the hood LIMIT = 0, STOP = 1
+    enum OrderTypes {
+        LIMIT,
+        STOP
+    }
+
     // marketKey: synthetix futures market id/key
     // margin: amount of margin (in sUSD) in specific futures market
     // size: denoted in market currency (i.e. ETH, BTC, etc), size of futures position
@@ -30,13 +37,15 @@ interface IMarginBaseTypes {
     // marketKey: synthetix futures market id/key
     // marginDelta: amount of margin (in sUSD) to deposit or withdraw
     // sizeDelta: denoted in market currency (i.e. ETH, BTC, etc), size of futures position
-    // desiredPrice: limit or stop price desired
+    // targetPrice: limit or stop price to fill at
     // gelatoTaskId: unqiue taskId from gelato necessary for cancelling orders
+    // orderType: order type to determine order fill logic
     struct Order {
         bytes32 marketKey;
         int256 marginDelta; // positive indicates deposit, negative withdraw
         int256 sizeDelta;
-        uint256 desiredPrice;
+        uint256 targetPrice;
         bytes32 gelatoTaskId;
+        OrderTypes orderType;
     }
 }


### PR DESCRIPTION
Adds a `validStopOrder` function which is just the inverse of `validLimitOrder`. We fill at a target price or "worse". Also creates an enum that enumerates between LIMIT and STOP order types.  

resolves #53 