### PR TITLE
Feat/advanced order fees

### DIFF
--- a/contracts/MarginBaseSettings.sol
+++ b/contracts/MarginBaseSettings.sol
@@ -33,7 +33,7 @@ contract MarginBaseSettings is Ownable {
 
     /// @notice denoted in Basis points (BPS) (One basis point is equal to 1/100th of 1%)
     /// @dev fee imposed on stop losses
-    uint256 public stopLossFee;
+    uint256 public stopOrderFee;
 
     /*///////////////////////////////////////////////////////////////
                                 Events
@@ -53,7 +53,7 @@ contract MarginBaseSettings is Ownable {
 
     /// @notice emitted after a successful stop loss fee change
     /// @param fee: fee denoted in BPS
-    event StopLossFeeChanged(uint256 fee);
+    event StopOrderFeeChanged(uint256 fee);
 
     /*///////////////////////////////////////////////////////////////
                                 Errors
@@ -74,12 +74,12 @@ contract MarginBaseSettings is Ownable {
     /// @param _treasury: Kwenta's Treasury Address
     /// @param _tradeFee: fee denoted in BPS
     /// @param _limitOrderFee: fee denoted in BPS
-    /// @param _stopLossFee: fee denoted in BPS
+    /// @param _stopOrderFee: fee denoted in BPS
     constructor(
         address _treasury,
         uint256 _tradeFee,
         uint256 _limitOrderFee,
-        uint256 _stopLossFee
+        uint256 _stopOrderFee
     ) {
         /// @notice ensure valid address for Kwenta Treasury
         if (_treasury == address(0)) { revert ZeroAddress(); }
@@ -90,12 +90,12 @@ contract MarginBaseSettings is Ownable {
         /// @notice ensure valid fees
         if (_tradeFee >= MAX_BPS) { revert InvalidFee(_tradeFee); }
         if (_limitOrderFee >= MAX_BPS) { revert InvalidFee(_limitOrderFee); }
-        if (_stopLossFee >= MAX_BPS) { revert InvalidFee(_stopLossFee); }
+        if (_stopOrderFee >= MAX_BPS) { revert InvalidFee(_stopOrderFee); }
 
         /// @notice set initial fees
         tradeFee = _tradeFee;
         limitOrderFee = _limitOrderFee;
-        stopLossFee = _stopLossFee;
+        stopOrderFee = _stopOrderFee;
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -140,13 +140,13 @@ contract MarginBaseSettings is Ownable {
 
     /// @notice set new stop loss fee
     /// @param _fee: fee denoted in BPS
-    function setStopLossFee(uint256 _fee) external onlyOwner {
+    function setStopOrderFee(uint256 _fee) external onlyOwner {
         /// @notice ensure valid fee
         if (_fee >= MAX_BPS) { revert InvalidFee(_fee); }
 
         /// @notice set fee
-        stopLossFee = _fee;
+        stopOrderFee = _fee;
 
-        emit StopLossFeeChanged(_fee);
+        emit StopOrderFeeChanged(_fee);
     }
 }

--- a/test/contracts/MarginBase.t.sol
+++ b/test/contracts/MarginBase.t.sol
@@ -1009,6 +1009,24 @@ contract MarginBaseTest is DSTest {
         assertEq(account.getNumberOfActivePositions(), 2);
     }
 
+    function testCanGetActivePosition() public {
+        deposit(1 ether);
+        mockExchangeRatesForDistributionTests();
+
+        IMarginBaseTypes.UpdateMarketPositionSpec[]
+            memory newPositions = new IMarginBaseTypes.UpdateMarketPositionSpec[](
+                1
+            );
+        newPositions[0] = IMarginBaseTypes.UpdateMarketPositionSpec(
+            ETH_MARKET_KEY,
+            1 ether,
+            1 ether
+        );
+
+        account.distributeMargin(newPositions);
+        assertTrue(account.activePositionInMarket(ETH_MARKET_KEY));
+    }
+
     /**********************************
      * getAllActiveMarketPositions()
      * @notice position.margin and position.size are calculated by Synthetix

--- a/test/contracts/MarginBaseSettings.t.sol
+++ b/test/contracts/MarginBaseSettings.t.sol
@@ -20,12 +20,12 @@ contract MarginBaseSettingsTest is DSTest {
         /// @notice denoted in Basis points (BPS) (One basis point is equal to 1/100th of 1%)
         uint256 tradeFee = 5; // 5 BPS
         uint256 limitOrderFee = 5; // 5 BPS
-        uint256 stopLossFee = 10; // 10 BPS
+        uint256 stopOrderFee = 10; // 10 BPS
         marginBaseSettings = new MarginBaseSettings(
             KWENTA_TREASURY,
             tradeFee,
             limitOrderFee,
-            stopLossFee
+            stopOrderFee
         );
     }
 
@@ -115,7 +115,7 @@ contract MarginBaseSettingsTest is DSTest {
      **********************************/
 
     /// @dev fuzz test
-    function testSettingStopLossFee(uint256 x) public {
+    function testSettingStopOrderFee(uint256 x) public {
         if (x >= 10_000) {
             cheats.expectRevert(
                 abi.encodeWithSelector(
@@ -123,16 +123,16 @@ contract MarginBaseSettingsTest is DSTest {
                     x
                 )
             );
-            marginBaseSettings.setStopLossFee(x);
+            marginBaseSettings.setStopOrderFee(x);
             return;
         }
-        marginBaseSettings.setStopLossFee(x);
-        assertTrue(marginBaseSettings.stopLossFee() == x);
+        marginBaseSettings.setStopOrderFee(x);
+        assertTrue(marginBaseSettings.stopOrderFee() == x);
     }
 
-    function testFailSetStopLossFeeIfNotOwner() public {
+    function testFailSetStopOrderFeeIfNotOwner() public {
         marginBaseSettings.transferOwnership(RANDOM_ADDRESS); // not a zero address
-        marginBaseSettings.setStopLossFee(1 ether);
+        marginBaseSettings.setStopOrderFee(1 ether);
     }
 
     // @TODO: test events


### PR DESCRIPTION
Fees for advanced orders (and potentially cross margin):

This one is probably dependent on the greater refactor and how that changes the logic @JaredBorders. But as of the current architecture, the proposed solution is to withdraw a fee after a position is modified. 

I realized that (previously) removing a fee from incoming margin could become an issue if the marginDelta is 0 but size is still being modified. Therefore -- we pretty much have to either pull it from an active position or from the margin balance to guarantee fee payment. The latter case to account for if a position is closed.

resolves #14 