### PR TITLE
🗑 Remove rescueERC20()

### DIFF
--- a/contracts/MarginBase.sol
+++ b/contracts/MarginBase.sol
@@ -954,18 +954,4 @@ contract MarginBase is MinimalProxyable, IMarginBase, OpsReady {
     function _abs(int256 x) internal pure returns (uint256) {
         return uint256(x < 0 ? -x : x);
     }
-
-    /// @notice added to support recovering trapped erc20 tokens
-    /// @param tokenAddress: address of token to be recovered
-    /// @param tokenAmount: amount of token to be recovered
-    function rescueERC20(address tokenAddress, uint256 tokenAmount)
-        external
-        onlyOwner
-    {
-        if (tokenAddress == address(marginAsset)) {
-            revert CannotRescueMarginAsset();
-        }
-        IERC20(tokenAddress).transfer(owner(), tokenAmount);
-        emit Rescued(tokenAddress, tokenAmount);
-    }
 }

--- a/contracts/interfaces/IMarginBase.sol
+++ b/contracts/interfaces/IMarginBase.sol
@@ -69,7 +69,4 @@ interface IMarginBase is IMarginBaseTypes {
         external
         view
         returns (bool canExec, bytes memory execPayload);
-
-    // Utility
-    function rescueERC20(address tokenAddress, uint256 tokenAmount) external;
 }

--- a/test/contracts/MarginBase.t.sol
+++ b/test/contracts/MarginBase.t.sol
@@ -843,37 +843,6 @@ contract MarginBaseTest is DSTest {
     }
 
     /********************************************************************
-     * rescueERC20()
-     ********************************************************************/
-    function testCanRescueToken() public {
-        MintableERC20 token = new MintableERC20(address(this), 1 ether);
-        token.transfer(address(account), 1 ether);
-        assertEq(token.balanceOf(address(this)), 0);
-        account.rescueERC20(address(token), 1 ether);
-        assertEq(token.balanceOf(address(this)), 1 ether);
-    }
-
-    function testCantRescueMarginAssetToken() public {
-        marginAsset.mint(address(this), 1 ether);
-        marginAsset.transfer(address(account), 1 ether);
-        assertEq(marginAsset.balanceOf(address(this)), 0);
-        cheats.expectRevert(
-            abi.encodeWithSelector(MarginBase.CannotRescueMarginAsset.selector)
-        );
-        account.rescueERC20(address(marginAsset), 1 ether);
-    }
-
-    function testCantRescueTokenIfNotOwner() public {
-        MintableERC20 token = new MintableERC20(address(this), 1 ether);
-        token.transfer(address(account), 1 ether);
-        cheats.expectRevert(
-            abi.encodePacked("Ownable: caller is not the owner")
-        );
-        cheats.prank(nonOwnerEOA); // non-owner calling rescueERC20()
-        account.rescueERC20(address(token), 1 ether);
-    }
-
-    /********************************************************************
      * Advanced Orders Logic
      ********************************************************************/
 


### PR DESCRIPTION
Fix high vulnerability relating to rescueERC20(). The solution was to remove the function as it was deemed unnecessary.

Closes https://github.com/Kwenta/margin-manager/issues/69

