### PR TITLE
(G-1) onlyOwner

### DIFF
--- a/contracts/MarginBase.sol
+++ b/contracts/MarginBase.sol
@@ -257,16 +257,12 @@ contract MarginBase is MinimalProxyable, IMarginBase, OpsReady {
     ///////////////////////////////////////////////////////////////*/
 
     /// @param _amount: amount of marginAsset to deposit into marginBase account
-    function deposit(uint256 _amount)
-        public
-        notZero(_amount, "_amount")
-        onlyOwner
-    {
+    function deposit(uint256 _amount) public onlyOwner {
         _deposit(_amount);
     }
 
     /// @dev see deposit() NatSpec
-    function _deposit(uint256 _amount) internal {
+    function _deposit(uint256 _amount) internal notZero(_amount, "_amount") {
         // transfer in margin asset from user
         // (will revert if user does not have amount specified)
         require(

--- a/contracts/MarginBase.sol
+++ b/contracts/MarginBase.sol
@@ -262,6 +262,11 @@ contract MarginBase is MinimalProxyable, IMarginBase, OpsReady {
         notZero(_amount, "_amount")
         onlyOwner
     {
+        _deposit(_amount);
+    }
+
+    /// @dev see deposit() NatSpec
+    function _deposit(uint256 _amount) internal {
         // transfer in margin asset from user
         // (will revert if user does not have amount specified)
         require(
@@ -315,7 +320,7 @@ contract MarginBase is MinimalProxyable, IMarginBase, OpsReady {
         uint256 _amount,
         NewPosition[] memory _newPositions
     ) external onlyOwner {
-        deposit(_amount);
+        _deposit(_amount);
         _distributeMargin(_newPositions, 0);
     }
 
@@ -330,6 +335,7 @@ contract MarginBase is MinimalProxyable, IMarginBase, OpsReady {
         _distributeMargin(_newPositions, 0);
     }
 
+    // @dev see distributeMargin() NatSpec
     function _distributeMargin(
         NewPosition[] memory _newPositions,
         uint256 _advancedOrderFee


### PR DESCRIPTION
closes https://github.com/Kwenta/margin-manager/issues/78

Create internal `_deposit()` following the design pattern established by `_distributeMargin()`. Removes duplicate modifier call

No tests are required for change