### PR TITLE
hotfixes

### DIFF
--- a/contracts/MarginBase.sol
+++ b/contracts/MarginBase.sol
@@ -867,6 +867,10 @@ contract MarginBase is MinimalProxyable, IMarginBase, OpsReady {
             sizeDelta: order.sizeDelta
         });
 
+        // remove task from gelato's side
+        /// @dev optimization done for gelato
+        IOps(ops).cancelTask(order.gelatoTaskId);
+
         // delete order from orders
         delete orders[_orderId];
 

--- a/contracts/MarginBase.sol
+++ b/contracts/MarginBase.sol
@@ -784,7 +784,7 @@ contract MarginBase is MinimalProxyable, IMarginBase, OpsReady {
         returns (uint256)
     {
         if (address(this).balance < 1 ether / 100) {
-            revert InsufficientEthBalance(address(this).balance, 1 ether / 10);
+            revert InsufficientEthBalance(address(this).balance, 1 ether / 100);
         }
         // if more margin is desired on the position we must commit the margin
         if (_marginDelta > 0) {

--- a/contracts/interfaces/IOps.sol
+++ b/contracts/interfaces/IOps.sol
@@ -54,4 +54,6 @@ interface IOps {
         address _resolverAddress,
         bytes memory _resolverData
     ) external pure returns (bytes32);
+
+    function taskCreator(bytes32 _taskId) external view returns (address);
 }

--- a/test/contracts/MarginBase.t.sol
+++ b/test/contracts/MarginBase.t.sol
@@ -1198,7 +1198,7 @@ contract MarginBaseTest is DSTest {
             abi.encodeWithSelector(
                 MarginBase.InsufficientEthBalance.selector,
                 0, // 0 ETH in account
-                1 ether / 10 // .1 ETH minimum
+                1 ether / 100 // .01 ETH minimum
             )
         );
 

--- a/test/contracts/MarginBase.t.sol
+++ b/test/contracts/MarginBase.t.sol
@@ -324,6 +324,13 @@ contract MarginBaseTest is DSTest {
             abi.encodePacked(IOps.gelato.selector),
             abi.encode(gelato)
         );
+
+        // mock gelato address getter
+        cheats.mockCall(
+            account.ops(),
+            abi.encodePacked(IOps.cancelTask.selector),
+            abi.encode(0)
+        );
     }
 
     /*///////////////////////////////////////////////////////////////
@@ -1553,19 +1560,7 @@ contract MarginBaseTest is DSTest {
         // make limit order condition
         mockExchangeRates(futuresMarketETH, limitPrice);
 
-        // mock gelato fee details
-        cheats.mockCall(
-            account.ops(),
-            abi.encodePacked(IOps.getFeeDetails.selector),
-            abi.encode(fee, account.ETH())
-        );
-
-        // mock gelato address getter
-        cheats.mockCall(
-            account.ops(),
-            abi.encodePacked(IOps.gelato.selector),
-            abi.encode(gelato)
-        );
+        mockGelato(fee);
 
         // expect a call w/ empty calldata to gelato (payment through callvalue)
         cheats.expectCall(gelato, "");

--- a/test/integration/order.behavior.ts
+++ b/test/integration/order.behavior.ts
@@ -287,6 +287,24 @@ describe("Integration: Test Advanced Orders", () => {
                     );
             });
 
+            it("Gelato task unregistered", async () => {
+                const gelatoTaskId = (await marginAccount.orders(0))
+                    .gelatoTaskId;
+
+                // Expect task to be registered
+                expect(await gelatoOps.taskCreator(gelatoTaskId)).to.be.equal(
+                    marginAccount.address
+                );
+
+                const { tx } = await executeOrder();
+                await tx;
+
+                // Expect that we cancel the task for gelato after execution
+                expect(await gelatoOps.taskCreator(gelatoTaskId)).to.be.equal(
+                    ethers.constants.AddressZero
+                );
+            });
+
             it("OrderFilled emitted", async () => {
                 const { tx } = await executeOrder();
 


### PR DESCRIPTION
Two changes in this PR:

- Simple fix to change the min ETH fee error when placing an order to `0.01 ETH`.
- Added in a call to cancel a gelato task during successful order execution. Was done because tasks are not automatically canceled after successful execution on Gelato's side costing them resources as they continually check for execution.