### PR TITLE
⛳️  Improve Minimal Proxy

### DIFF
--- a/contracts/utils/MinimalProxyFactory.sol
+++ b/contracts/utils/MinimalProxyFactory.sol
@@ -30,9 +30,9 @@ contract MinimalProxyFactory {
                 //---- constructor -----
                 bytes10(0x3d602d80600a3d3981f3),
                 //---- proxy code -----
-                bytes10(0x363d3d373d3d3d363d73),
+                bytes11(0x3d3d3d3d363d3d37363d73),
                 _base,
-                bytes15(0x5af43d82803e903d91602b57fd5bf3)
+                bytes13(0x5af43d3d93803e602a57fd5bf3)
             );
     }
 }

--- a/test/contracts/MarginAccountFactory.t.sol
+++ b/test/contracts/MarginAccountFactory.t.sol
@@ -85,4 +85,17 @@ contract MarginAccountFactoryTest is DSTest {
         MarginBase account = MarginBase(marginAccountFactory.newAccount());
         assertEq(account.owner(), address(this));
     }
+
+    function testCannotInitAccountTwice() public {
+        MarginBase account = MarginBase(
+            payable(marginAccountFactory.newAccount())
+        );
+        cheats.expectRevert();
+        account.initialize(
+            address(0),
+            address(0),
+            address(0),
+            payable(address(0))
+        );
+    }
 }


### PR DESCRIPTION
⛳️ Update Bytecode

Edit:
One less swap, and a returndatasize instead of a dup to boot. This translates to 200 less gas to deploy (one fewer byte of runtime code) and 4 less gas to call (the swap we got rid of costs three gas, and returndatasize costs one less gas than dup).

closes https://github.com/Kwenta/margin-manager/issues/99
closes https://github.com/Kwenta/margin-manager/issues/32