### PR TITLE
🏭 Multiple Accounts Per Owner

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,6 +1,7 @@
 {
     "extends": "solhint:recommended",
     "rules": {
+        "no-global-import": "off",
         "no-inline-assembly": "off",
         "func-name-mixedcase": "off",
         "no-empty-blocks": "off",

--- a/README.md
+++ b/README.md
@@ -85,13 +85,23 @@ Finally, all associated functionality related to upgradability can be disabled b
 
 ## Folder Structure
 
-    ├── ...
-    ├── src                     # Source contracts
-    ├── script                  # Foundry deployment scripts
-    ├── test                    # Test files
-    │   ├── integration         # End-to-end, integration tests using Foundry
-    │   └── unit                # Contract focused, fuzzed/non-fuzzed tests using Foundry
-    └── ...
+src
+├── Account.sol
+├── AccountProxy.sol
+├── Events.sol
+├── Factory.sol
+├── Settings.sol
+├── interfaces
+│   ├── IAccount.sol
+│   ├── IAccountProxy.sol
+│   ├── IEvents.sol
+│   ├── IFactory.sol
+│   ├── IOps.sol
+│   ├── ISettings.sol
+│   └── synthetix
+│       ├── (...)
+└── utils
+    └── OpsReady.sol
 
 ## Test Coverage
 

--- a/src/Account.sol
+++ b/src/Account.sol
@@ -122,6 +122,9 @@ contract Account is IAccount, OpsReady, Owned, Initializable {
 
         settings = ISettings(_settings);
         events = IEvents(_events);
+
+        // @TODO consider removing factory from account before audit
+        // (keep for now incase we need it later?)
         factory = IFactory(_factory);
 
         // get address for futures market manager

--- a/src/Account.sol
+++ b/src/Account.sol
@@ -194,14 +194,15 @@ contract Account is IAccount, OpsReady, Owned, Initializable {
                                OWNERSHIP
     //////////////////////////////////////////////////////////////*/
 
-    function transferOwnership(address _newOwner)
-        public
-        override
-        onlyOwner
-    {
-        owner = _newOwner;
+    /// @inheritdoc Owned
+    function transferOwnership(address _newOwner) public override onlyOwner {
+        // update the factory's record of owners and account addresses
+        factory.updateAccountOwnership({
+            _account: address(this),
+            _newOwner: _newOwner
+        });
 
-        emit OwnershipTransferred(msg.sender, _newOwner);
+        super.transferOwnership(_newOwner);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/Account.sol
+++ b/src/Account.sol
@@ -191,6 +191,20 @@ contract Account is IAccount, OpsReady, Owned, Initializable {
     }
 
     /*//////////////////////////////////////////////////////////////
+                               OWNERSHIP
+    //////////////////////////////////////////////////////////////*/
+
+    function transferOwnership(address _newOwner)
+        public
+        override
+        onlyOwner
+    {
+        owner = _newOwner;
+
+        emit OwnershipTransferred(msg.sender, _newOwner);
+    }
+
+    /*//////////////////////////////////////////////////////////////
                                EXECUTION
     //////////////////////////////////////////////////////////////*/
 

--- a/src/Account.sol
+++ b/src/Account.sol
@@ -188,18 +188,6 @@ contract Account is IAccount, OpsReady, Owned, Initializable {
     }
 
     /*//////////////////////////////////////////////////////////////
-                           ACCOUNT OWNERSHIP
-    //////////////////////////////////////////////////////////////*/
-
-    /// @notice transfer ownership of this account to a new address
-    /// @dev will update factory's mapping record of owner to account
-    /// @param _newOwner: address to transfer ownership to
-    function transferOwnership(address _newOwner) public override onlyOwner {
-        factory.updateAccountOwner({_oldOwner: owner, _newOwner: _newOwner});
-        super.transferOwnership(_newOwner);
-    }
-
-    /*//////////////////////////////////////////////////////////////
                                EXECUTION
     //////////////////////////////////////////////////////////////*/
 

--- a/src/interfaces/IFactory.sol
+++ b/src/interfaces/IFactory.sol
@@ -45,6 +45,9 @@ interface IFactory {
     /// @notice thrown when account is unrecognized by factory
     error AccountDoesNotExist();
 
+    /// @notice thrown when caller is not a factory authenticated account
+    error OnlyAccount();
+
     /*//////////////////////////////////////////////////////////////
                                  VIEWS
     //////////////////////////////////////////////////////////////*/
@@ -61,8 +64,8 @@ interface IFactory {
     /// @return events: address of events contract for accounts
     function events() external view returns (address);
 
-    /// @return whether or not account exists
     /// @param _account: address of account
+    /// @return whether or not account exists
     function accounts(address _account) external view returns (bool);
 
     /// @param _account: address of account
@@ -72,8 +75,26 @@ interface IFactory {
         view
         returns (address);
 
+    /// @param _owner: address of owner
+    /// @return array of accounts owned by _owner
+    function getAccountsOwnedBy(address _owner)
+        external
+        view
+        returns (address[] memory);
+
     /*//////////////////////////////////////////////////////////////
-                                MUTATIVE
+                               OWNERSHIP
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice update owner to account(s) mapping
+    /// @dev does *NOT* check new owner != old owner
+    /// @param _account: account whose owner is being updated
+    /// @param _newOwner: new owner of account
+    function updateAccountOwnership(address _account, address _newOwner)
+        external;
+
+    /*//////////////////////////////////////////////////////////////
+                           ACCOUNT DEPLOYMENT
     //////////////////////////////////////////////////////////////*/
 
     /// @notice create unique account proxy for function caller

--- a/src/interfaces/IFactory.sol
+++ b/src/interfaces/IFactory.sol
@@ -31,11 +31,6 @@ interface IFactory {
                                  ERRORS
     //////////////////////////////////////////////////////////////*/
 
-    /// @notice thrown when newAccount() is called
-    /// by an address which has already made an account
-    /// @param account: address of account previously created
-    error OnlyOneAccountPerAddress(address account);
-
     /// @notice thrown when Account creation fails at initialization step
     /// @param data: data returned from failed low-level call
     error AccountFailedToInitialize(bytes data);
@@ -47,17 +42,14 @@ interface IFactory {
     /// @notice thrown when factory is not upgradable
     error CannotUpgrade();
 
-    /// @notice thrown account owner is unrecognized via ownerToAccount mapping
+    /// @notice thrown when account is unrecognized by factory
     error AccountDoesNotExist();
-
-    /// @notice thrown when caller is not an account
-    error CallerMustBeAccount();
 
     /*//////////////////////////////////////////////////////////////
                                  VIEWS
     //////////////////////////////////////////////////////////////*/
 
-    /// @return canUpgrade: bool to determine if factory can be upgraded
+    /// @return canUpgrade: bool to determine if system can be upgraded
     function canUpgrade() external view returns (bool);
 
     /// @return logic: account logic address
@@ -69,9 +61,16 @@ interface IFactory {
     /// @return events: address of events contract for accounts
     function events() external view returns (address);
 
-    /// @return address of account owned by _owner
-    /// @param _owner: owner of account
-    function ownerToAccount(address _owner) external view returns (address);
+    /// @return whether or not account exists
+    /// @param _account: address of account
+    function accounts(address _account) external view returns (bool);
+
+    /// @param _account: address of account
+    /// @return owner of account
+    function getAccountOwner(address _account)
+        external
+        view
+        returns (address);
 
     /*//////////////////////////////////////////////////////////////
                                 MUTATIVE
@@ -80,12 +79,6 @@ interface IFactory {
     /// @notice create unique account proxy for function caller
     /// @return accountAddress address of account created
     function newAccount() external returns (address payable accountAddress);
-
-    /// @notice update account owner
-    /// @param _oldOwner: old owner of account
-    /// @param _newOwner: new owner of account
-    function updateAccountOwner(address _oldOwner, address _newOwner)
-        external;
 
     /*//////////////////////////////////////////////////////////////
                              UPGRADABILITY

--- a/test/unit/Account.t.sol
+++ b/test/unit/Account.t.sol
@@ -179,7 +179,11 @@ contract AccountTest is Test, ConsolidatedEvents {
     function test_ownership_transfer() external {
         // ensure factory and account state align
         address currentOwner = factory.getAccountOwner(address(account));
-        assert(currentOwner == address(this) && currentOwner == account.owner());
+        assert(
+            currentOwner == address(this) && currentOwner == account.owner()
+                && currentOwner != KWENTA_TREASURY
+        );
+        assert(factory.getAccountsOwnedBy(currentOwner)[0] == address(account));
 
         // transfer ownership
         account.transferOwnership(KWENTA_TREASURY);
@@ -189,6 +193,9 @@ contract AccountTest is Test, ConsolidatedEvents {
         currentOwner = factory.getAccountOwner(address(account));
         assert(
             currentOwner == KWENTA_TREASURY && currentOwner == account.owner()
+        );
+        assert(
+            factory.getAccountsOwnedBy(KWENTA_TREASURY)[0] == address(account)
         );
     }
 

--- a/test/unit/Account.t.sol
+++ b/test/unit/Account.t.sol
@@ -173,6 +173,26 @@ contract AccountTest is Test, ConsolidatedEvents {
     }
 
     /*//////////////////////////////////////////////////////////////
+                               OWNERSHIP
+    //////////////////////////////////////////////////////////////*/
+
+    function test_ownership_transfer() external {
+        // ensure factory and account state align
+        address currentOwner = factory.getAccountOwner(address(account));
+        assert(currentOwner == address(this) && currentOwner == account.owner());
+
+        // transfer ownership
+        account.transferOwnership(KWENTA_TREASURY);
+        assert(account.owner() == KWENTA_TREASURY);
+
+        // ensure factory and account state align
+        currentOwner = factory.getAccountOwner(address(account));
+        assert(
+            currentOwner == KWENTA_TREASURY && currentOwner == account.owner()
+        );
+    }
+
+    /*//////////////////////////////////////////////////////////////
                        ACCOUNT DEPOSITS/WITHDRAWS
     //////////////////////////////////////////////////////////////*/
 

--- a/test/unit/Factory.t.sol
+++ b/test/unit/Factory.t.sol
@@ -52,36 +52,51 @@ contract FactoryTest is Test, ConsolidatedEvents {
                               CONSTRUCTOR
     //////////////////////////////////////////////////////////////*/
 
-    function test_OwnerSet() public {
+    function test_Constructor_Owner() public {
         assertEq(factory.owner(), address(this));
     }
 
-    function test_CanUpgrade() public {
-        assertEq(factory.canUpgrade(), true);
+    function test_Constructor_Settings() public {
+        assertEq(address(factory.settings()), address(settings));
     }
 
-    function test_ImplementationSet() public {
+    function test_Constructor_Events() public {
+        assertEq(address(factory.events()), address(events));
+    }
+
+    function test_Constructor_Implementation() public {
         assertEq(factory.implementation(), address(implementation));
     }
 
-    function test_SettingsSet() public {
-        assertEq(address(factory.settings()), address(settings));
+    function test_Constructor_CanUpgrade() public {
+        assertEq(factory.canUpgrade(), true);
+    }
+
+    function test_Constructor_Accounts(address fuzzedAddress) public view {
+        assert(!factory.accounts(fuzzedAddress));
     }
 
     /*//////////////////////////////////////////////////////////////
                            FACTORY OWNERSHIP
     //////////////////////////////////////////////////////////////*/
 
-    function test_CanTransferOwnership() public {
-        factory.transferOwnership(address(0xCAFEBAE));
-        assertEq(factory.owner(), address(0xCAFEBAE));
+    function test_Ownership_Transfer() public {
+        factory.transferOwnership(USER);
+        assertEq(factory.owner(), USER);
+    }
+
+    function test_Ownership_NonAccount() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(IFactory.AccountDoesNotExist.selector)
+        );
+        factory.getAccountOwner(address(0));
     }
 
     /*//////////////////////////////////////////////////////////////
                            ACCOUNT DEPLOYMENT
     //////////////////////////////////////////////////////////////*/
 
-    function test_NewAccount() public {
+    function test_NewAccount_Address() public {
         address payable accountAddress = factory.newAccount();
         assert(accountAddress != address(0));
     }
@@ -92,19 +107,20 @@ contract FactoryTest is Test, ConsolidatedEvents {
         factory.newAccount();
     }
 
-    function test_AccountAddedToMapping() public {
+    function test_NewAccount_State() public {
         address payable accountAddress = factory.newAccount();
-        assertEq(factory.ownerToAccount(address(this)), accountAddress);
+        assert(factory.accounts(accountAddress));
     }
 
-    function test_CannotCreateTwoAccounts() public {
-        address payable accountAddress = factory.newAccount();
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IFactory.OnlyOneAccountPerAddress.selector, accountAddress
-            )
+    function test_NewAccount_MultiplePerAddress() public {
+        address payable accountAddress1 = factory.newAccount();
+        assert(factory.accounts(accountAddress1));
+        address payable accountAddress2 = factory.newAccount();
+        assert(factory.accounts(accountAddress2));
+        assertEq(
+            factory.getAccountOwner(accountAddress1),
+            factory.getAccountOwner(accountAddress2)
         );
-        factory.newAccount();
     }
 
     /// @dev this error does not catch 100% of scenarios.
@@ -115,7 +131,7 @@ contract FactoryTest is Test, ConsolidatedEvents {
     ///
     /// Given this, it is up to the factory owner to take
     /// extra care when creating the implementation to be used
-    function test_AccountCannotBeInitialized() public {
+    function test_NewAccount_CannotBeInitialized() public {
         MockAccount1 mockAccount = new MockAccount1();
         factory = new Factory({
             _owner: address(this),
@@ -139,7 +155,7 @@ contract FactoryTest is Test, ConsolidatedEvents {
     ///
     /// Given this, it is up to the factory owner to take
     /// extra care when creating the implementation to be used
-    function test_AccountCannotFetchVersion() public {
+    function test_NewAccount_CannotFetchVersion() public {
         MockAccount2 mockAccount = new MockAccount2();
         factory = new Factory({
             _owner: address(this),
@@ -156,76 +172,35 @@ contract FactoryTest is Test, ConsolidatedEvents {
     }
 
     /*//////////////////////////////////////////////////////////////
-                           ACCOUNT OWNERSHIP
-    //////////////////////////////////////////////////////////////*/
-
-    function test_AccountCanTransferAccountOwnership() public {
-        address payable accountAddress = factory.newAccount();
-        Account(accountAddress).transferOwnership({
-            _newOwner: address(0xCAFEBAE)
-        });
-        assertEq(factory.ownerToAccount(address(this)), address(0));
-        assertEq(factory.ownerToAccount(address(0xCAFEBAE)), accountAddress);
-        assertEq(Account(accountAddress).owner(), address(0xCAFEBAE));
-    }
-
-    function test_AccountCannotTransferOwnershipToAnotherAccountOwningAddress()
-        public
-    {
-        address payable accountAddress1 = factory.newAccount();
-        vm.prank(ACCOUNT);
-        address payable accountAddress2 = factory.newAccount();
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                IFactory.OnlyOneAccountPerAddress.selector, accountAddress2
-            )
-        );
-        Account(accountAddress1).transferOwnership({_newOwner: ACCOUNT});
-    }
-
-    function test_AccountOwnerCannotTransferAnotherAccount() public {
-        factory.newAccount();
-        vm.prank(ACCOUNT);
-        factory.newAccount();
-        vm.expectRevert(
-            abi.encodeWithSelector(IFactory.CallerMustBeAccount.selector)
-        );
-        // try to brick account owned by ACCOUNT
-        factory.updateAccountOwner({_oldOwner: ACCOUNT, _newOwner: address(0)});
-    }
-
-    function test_CannotUpdateAccountThatDoesNotExist() public {
-        vm.expectRevert(
-            abi.encodeWithSelector(IFactory.AccountDoesNotExist.selector)
-        );
-        factory.updateAccountOwner({
-            _oldOwner: address(0xCAFEBAE),
-            _newOwner: address(0xBEEF)
-        });
-    }
-
-    function test_CannotDirectlyUpdateAccount() public {
-        factory.newAccount();
-        vm.expectRevert(
-            abi.encodeWithSelector(IFactory.CallerMustBeAccount.selector)
-        );
-        factory.updateAccountOwner({
-            _oldOwner: address(this),
-            _newOwner: address(0xBEEF)
-        });
-    }
-
-    /*//////////////////////////////////////////////////////////////
                              UPGRADABILITY
     //////////////////////////////////////////////////////////////*/
 
-    function test_UpgradeAccountImplementation_OnlyOwner() public {
+    /*//////////////////////////////////////////////////////////////
+                          REMOVE UPGRADABILITY
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Upgrade_Remove_OnlyOwner() public {
+        vm.expectRevert("UNAUTHORIZED");
+        vm.prank(ACCOUNT);
+        factory.removeUpgradability();
+    }
+
+    function test_Upgrade_Remove() public {
+        factory.removeUpgradability();
+        assertEq(factory.canUpgrade(), false);
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                             IMPLEMENTATION
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Upgrade_Implementation_OnlyOwner() public {
         vm.expectRevert("UNAUTHORIZED");
         vm.prank(ACCOUNT);
         factory.upgradeAccountImplementation({_implementation: address(0)});
     }
 
-    function test_UpgradeAccountImplementation() public {
+    function test_Upgrade_Implementation() public {
         address payable accountAddress = factory.newAccount();
         UpgradedAccount newImplementation = new UpgradedAccount();
         factory.upgradeAccountImplementation({
@@ -243,23 +218,33 @@ contract FactoryTest is Test, ConsolidatedEvents {
         assertEq(Account(accountAddress2).owner(), ACCOUNT);
     }
 
-    function test_UpgradeAccountImplementation_Event() public {
+    function test_Upgrade_Implementation_Event() public {
         vm.expectEmit(true, true, true, true);
         emit AccountImplementationUpgraded(address(0));
         factory.upgradeAccountImplementation({_implementation: address(0)});
     }
 
-    function test_UpgradeSettings_OnlyOwner() public {
+    function test_Upgrade_Implementation_UpgradabilityRemoved() public {
+        factory.removeUpgradability();
+        vm.expectRevert(abi.encodeWithSelector(IFactory.CannotUpgrade.selector));
+        factory.upgradeAccountImplementation({_implementation: address(0)});
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                SETTINGS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Upgrade_Settings_OnlyOwner() public {
         vm.expectRevert("UNAUTHORIZED");
         vm.prank(KWENTA_TREASURY);
         factory.upgradeSettings({_settings: address(0)});
     }
 
-    function test_UpgradeSettings() public {
+    function test_Upgrade_Settings() public {
         address payable accountAddress = factory.newAccount();
         address newSettings = address(
             new Settings({
-                _owner: ACCOUNT, // change owner
+                _owner: ACCOUNT, // this upgrade changes owner
                 _treasury: KWENTA_TREASURY,
                 _tradeFee: TRADE_FEE,
                 _limitOrderFee: LIMIT_ORDER_FEE,
@@ -273,7 +258,6 @@ contract FactoryTest is Test, ConsolidatedEvents {
             address(this)
         );
         // check new account uses new settings
-        vm.prank(ACCOUNT);
         address payable accountAddress2 = factory.newAccount();
         // check new accounts settings owner did change
         assertEq(
@@ -282,32 +266,47 @@ contract FactoryTest is Test, ConsolidatedEvents {
         );
     }
 
-    function test_UpgradeSettings_Event() public {
+    function test_Upgrade_Settings_Event() public {
         vm.expectEmit(true, true, true, true);
         emit SettingsUpgraded(address(0));
         factory.upgradeSettings({_settings: address(0)});
     }
 
-    function test_RemoveUpgradability_OnlyOwner() public {
-        vm.expectRevert("UNAUTHORIZED");
-        vm.prank(ACCOUNT);
-        factory.removeUpgradability();
-    }
-
-    function test_RemoveUpgradability() public {
-        factory.removeUpgradability();
-        assertEq(factory.canUpgrade(), false);
-    }
-
-    function test_UpgradeAccountImplementation_NotEnabled() public {
-        factory.removeUpgradability();
-        vm.expectRevert(abi.encodeWithSelector(IFactory.CannotUpgrade.selector));
-        factory.upgradeAccountImplementation({_implementation: address(0)});
-    }
-
-    function test_UpgradeSettings_NotEnabled() public {
+    function test_Upgrade_Settings_UpgradabilityRemoved() public {
         factory.removeUpgradability();
         vm.expectRevert(abi.encodeWithSelector(IFactory.CannotUpgrade.selector));
         factory.upgradeSettings({_settings: address(0)});
+    }
+
+    /*//////////////////////////////////////////////////////////////
+                                 EVENTS
+    //////////////////////////////////////////////////////////////*/
+
+    function test_Upgrade_Events_OnlyOwner() public {
+        vm.expectRevert("UNAUTHORIZED");
+        vm.prank(KWENTA_TREASURY);
+        factory.upgradeEvents({_events: address(0)});
+    }
+
+    function test_Upgrade_Events() public {
+        address payable accountAddress = factory.newAccount();
+        factory.upgradeEvents({_events: address(0)});
+        // check upgrade did not impact previously deployed account
+        assert(address(Account(accountAddress).events()) != address(0));
+        // check new account uses new events
+        address payable accountAddress2 = factory.newAccount();
+        assert(address(Account(accountAddress2).events()) == address(0));
+    }
+
+    function test_Upgrade_Events_Event() public {
+        vm.expectEmit(true, true, true, true);
+        emit EventsUpgraded(address(0));
+        factory.upgradeEvents({_events: address(0)});
+    }
+
+    function test_Upgrade_Events_UpgradabilityRemoved() public {
+        factory.removeUpgradability();
+        vm.expectRevert(abi.encodeWithSelector(IFactory.CannotUpgrade.selector));
+        factory.upgradeEvents({_events: address(0)});
     }
 }


### PR DESCRIPTION
Let owners create and operate multiple smart margin accounts.

## Description
* Create a new mapping that tracks account addresses
* Create a new mapping that tracks owner to account(s)
* Test new mappings
* Update tests that used old mappings
* Add several more tests for transferring account ownership
* Test state alignment between factory and accounts

### Discussion
CMv1 did not track accounts. FE requested this feature to reduce reliance on subgraphs. 

1-to-1 owner-to-account mapping is trivial; however, with the 1-to-many owner-to-account mapping adds complexity better left off-chain. 

Reasoning:
Updating the mapping to support 1-to-many significantly increases the gas needed to update the owner (i.e., navigating through an array to remove an address and then shifting elements + appending an address to a new array for the new owner). 
Updating the mapping to support 1-to-many also increases the attack surface with little to no benefit when another solution to account ownership transfers and factory-based account tracking exists.


Solution:
Track accounts via 1-to-1 mapping (account address => `bool` representing whether it exists) and add a view function that queries the account's owner via an external call. This also reduces the gas needed when an account transfers its ownership to a new address. The biggest downside is that an easy owner-to-account lookup on-chain will not be possible. 


## Update
After discussing with the team, I added an owner => account(s) mapping. Both new mappings are necessary for future work.

## Related issue(s)
https://github.com/Kwenta/margin-manager/issues/128

## Motivation and Context
v2.0.0