### PR TITLE
📣 Improve Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Encoding parameters in a bytes string in this way gives us maximum flexiblity to
 
 For a more detailed breakdown of which parameters you should provide for each command take a look at the `Account.dispatch` function.
 
-Developer documentation to give a detailed explanation of the inputs for every command can be found in the [wiki](https://github.com/Kwenta/margin-manager/wiki/Commands-&-Inputs)
+Developer documentation to give a detailed explanation of the inputs for every command can be found in the [wiki](https://github.com/Kwenta/margin-manager/wiki/Commands)
 
 #### Diagram
 

--- a/src/Account.sol
+++ b/src/Account.sol
@@ -453,14 +453,15 @@ contract Account is IAccount, OpsReady, Auth, Initializable {
         int256 _sizeDelta,
         uint256 _priceImpactDelta
     ) internal {
-        _imposeFee(
-            _calculateFee({
+        _imposeFee({
+            _fee: _calculateFee({
                 _sizeDelta: _sizeDelta,
                 _market: IPerpsV2MarketConsolidated(_market),
                 _conditionalOrderFee: 0
             }),
-            "TRADE_FEE"
-        );
+            _marketKey: IPerpsV2MarketConsolidated(_market).marketKey(),
+            _reason: FeeReason.TRADE_FEE
+        });
 
         IPerpsV2MarketConsolidated(_market).modifyPositionWithTracking({
             sizeDelta: _sizeDelta,
@@ -485,14 +486,15 @@ contract Account is IAccount, OpsReady, Auth, Initializable {
             _priceImpactDelta, TRACKING_CODE
         );
 
-        _imposeFee(
-            _calculateFee({
+        _imposeFee({
+            _fee: _calculateFee({
                 _sizeDelta: getPosition(marketKey).size,
                 _market: IPerpsV2MarketConsolidated(_market),
                 _conditionalOrderFee: 0
             }),
-            "TRADE_FEE"
-        );
+            _marketKey: marketKey,
+            _reason: FeeReason.TRADE_FEE
+        });
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -511,14 +513,15 @@ contract Account is IAccount, OpsReady, Auth, Initializable {
         uint256 _priceImpactDelta,
         uint256 _desiredTimeDelta
     ) internal {
-        _imposeFee(
-            _calculateFee({
+        _imposeFee({
+            _fee: _calculateFee({
                 _sizeDelta: _sizeDelta,
                 _market: IPerpsV2MarketConsolidated(_market),
                 _conditionalOrderFee: 0
             }),
-            "TRADE_FEE"
-        );
+            _marketKey: IPerpsV2MarketConsolidated(_market).marketKey(),
+            _reason: FeeReason.TRADE_FEE
+        });
 
         IPerpsV2MarketConsolidated(_market).submitDelayedOrderWithTracking({
             sizeDelta: _sizeDelta,
@@ -548,14 +551,15 @@ contract Account is IAccount, OpsReady, Auth, Initializable {
         int256 _sizeDelta,
         uint256 _priceImpactDelta
     ) internal {
-        _imposeFee(
-            _calculateFee({
+        _imposeFee({
+            _fee: _calculateFee({
                 _sizeDelta: _sizeDelta,
                 _market: IPerpsV2MarketConsolidated(_market),
                 _conditionalOrderFee: 0
             }),
-            "TRADE_FEE"
-        );
+            _marketKey: IPerpsV2MarketConsolidated(_market).marketKey(),
+            _reason: FeeReason.TRADE_FEE
+        });
 
         IPerpsV2MarketConsolidated(_market)
             .submitOffchainDelayedOrderWithTracking({
@@ -712,7 +716,7 @@ contract Account is IAccount, OpsReady, Auth, Initializable {
             _validConditionalOrder(_conditionalOrderId);
 
         // Account.checker() will prevent this from being called if the conditional order is not valid
-        /// @dev this is a safety check; never intended to fail
+        /// @dev this is a safety/sanity check; never intended to fail
         assert(isValidConditionalOrder);
 
         ConditionalOrder memory conditionalOrder =
@@ -782,14 +786,15 @@ contract Account is IAccount, OpsReady, Auth, Initializable {
         _transfer({_amount: fee, _paymentToken: feeToken});
 
         // pay Kwenta imposed fee for both the trade and the conditional order execution
-        _imposeFee(
-            _calculateFee({
+        _imposeFee({
+            _fee: _calculateFee({
                 _sizeDelta: conditionalOrder.sizeDelta,
                 _market: IPerpsV2MarketConsolidated(market),
                 _conditionalOrderFee: conditionalOrderFee
             }),
-            "TRADE_AND_CONDITIONAL_ORDER_FEE"
-        );
+            _marketKey: conditionalOrder.marketKey,
+            _reason: FeeReason.TRADE_AND_CONDITIONAL_ORDER_FEE
+        });
 
         events.emitConditionalOrderFilled({
             account: address(this),
@@ -901,7 +906,11 @@ contract Account is IAccount, OpsReady, Auth, Initializable {
 
     /// @notice impose fee on account
     /// @param _fee: fee to impose
-    function _imposeFee(uint256 _fee, bytes32 _reason) internal {
+    /// @param _marketKey: key for Synthetix PerpsV2 market
+    /// @param _reason: reason for fee
+    function _imposeFee(uint256 _fee, bytes32 _marketKey, FeeReason _reason)
+        internal
+    {
         /// @dev send fee to Kwenta's treasury
         if (_fee > freeMargin()) {
             // fee canot be greater than available margin
@@ -914,7 +923,8 @@ contract Account is IAccount, OpsReady, Auth, Initializable {
             events.emitFeeImposed({
                 account: address(this),
                 amount: _fee,
-                reason: _reason
+                marketKey: _marketKey,
+                reason: bytes32(uint256(_reason))
             });
         }
     }

--- a/src/Account.sol
+++ b/src/Account.sol
@@ -786,12 +786,13 @@ contract Account is IAccount, OpsReady, Auth, Initializable {
         _transfer({_amount: fee, _paymentToken: feeToken});
 
         // pay Kwenta imposed fee for both the trade and the conditional order execution
+        uint256 kwentaImposedFee = _calculateFee({
+            _sizeDelta: conditionalOrder.sizeDelta,
+            _market: IPerpsV2MarketConsolidated(market),
+            _conditionalOrderFee: conditionalOrderFee
+        });
         _imposeFee({
-            _fee: _calculateFee({
-                _sizeDelta: conditionalOrder.sizeDelta,
-                _market: IPerpsV2MarketConsolidated(market),
-                _conditionalOrderFee: conditionalOrderFee
-            }),
+            _fee: kwentaImposedFee,
             _marketKey: conditionalOrder.marketKey,
             _reason: FeeReason.TRADE_AND_CONDITIONAL_ORDER_FEE
         });
@@ -800,7 +801,8 @@ contract Account is IAccount, OpsReady, Auth, Initializable {
             account: address(this),
             conditionalOrderId: _conditionalOrderId,
             fillPrice: fillPrice,
-            keeperFee: fee
+            keeperFee: fee,
+            kwentaFee: kwentaImposedFee
         });
     }
 

--- a/src/Events.sol
+++ b/src/Events.sol
@@ -112,13 +112,15 @@ contract Events is IEvents {
         address account,
         uint256 conditionalOrderId,
         uint256 fillPrice,
-        uint256 keeperFee
+        uint256 keeperFee,
+        uint256 kwentaFee
     ) external override onlyAccounts {
         emit ConditionalOrderFilled({
             account: account,
             conditionalOrderId: conditionalOrderId,
             fillPrice: fillPrice,
-            keeperFee: keeperFee
+            keeperFee: keeperFee,
+            kwentaFee: kwentaFee
         });
     }
 

--- a/src/Events.sol
+++ b/src/Events.sol
@@ -123,11 +123,11 @@ contract Events is IEvents {
     }
 
     /// @inheritdoc IEvents
-    function emitFeeImposed(address account, uint256 amount)
+    function emitFeeImposed(address account, uint256 amount, bytes32 reason)
         external
         override
         onlyAccounts
     {
-        emit FeeImposed({account: account, amount: amount});
+        emit FeeImposed({account: account, amount: amount, reason: reason});
     }
 }

--- a/src/Events.sol
+++ b/src/Events.sol
@@ -123,11 +123,17 @@ contract Events is IEvents {
     }
 
     /// @inheritdoc IEvents
-    function emitFeeImposed(address account, uint256 amount, bytes32 reason)
-        external
-        override
-        onlyAccounts
-    {
-        emit FeeImposed({account: account, amount: amount, reason: reason});
+    function emitFeeImposed(
+        address account,
+        uint256 amount,
+        bytes32 marketKey,
+        bytes32 reason
+    ) external override onlyAccounts {
+        emit FeeImposed({
+            account: account,
+            amount: amount,
+            marketKey: marketKey,
+            reason: reason
+        });
     }
 }

--- a/src/interfaces/IAccount.sol
+++ b/src/interfaces/IAccount.sol
@@ -48,6 +48,14 @@ interface IAccount {
         CONDITIONAL_ORDER_CANCELLED_NOT_REDUCE_ONLY
     }
 
+    /// @notice denotes imposed fee reasons for code clarity
+    /// @dev under the hood TRADE_FEE = 0, TRADE_AND_CONDITIONAL_ORDER_FEE = 1
+    /// @dev expect to see further fee reasons in the future (i.e. delagates, etc)
+    enum FeeReason {
+        TRADE_FEE,
+        TRADE_AND_CONDITIONAL_ORDER_FEE
+    }
+
     /// marketKey: Synthetix PerpsV2 Market id/key
     /// marginDelta: amount of margin to deposit or withdraw; positive indicates deposit, negative withdraw
     /// sizeDelta: denoted in market currency (i.e. ETH, BTC, etc), size of Synthetix PerpsV2 position

--- a/src/interfaces/IEvents.sol
+++ b/src/interfaces/IEvents.sol
@@ -112,18 +112,21 @@ interface IEvents {
     /// @param conditionalOrderId: id of conditional order
     /// @param fillPrice: price the conditional order was executed at
     /// @param keeperFee: fees paid to the executor
+    /// @param kwentaFee: fees paid to Kwenta
     function emitConditionalOrderFilled(
         address account,
         uint256 conditionalOrderId,
         uint256 fillPrice,
-        uint256 keeperFee
+        uint256 keeperFee,
+        uint256 kwentaFee
     ) external;
 
     event ConditionalOrderFilled(
         address indexed account,
         uint256 conditionalOrderId,
         uint256 fillPrice,
-        uint256 keeperFee
+        uint256 keeperFee,
+        uint256 kwentaFee
     );
 
     /// @notice emitted after a fee has been transferred to Treasury

--- a/src/interfaces/IEvents.sol
+++ b/src/interfaces/IEvents.sol
@@ -31,7 +31,6 @@ interface IEvents {
     function emitDeposit(address user, address account, uint256 amount)
         external;
 
-    // @inheritdoc IAccount
     event Deposit(
         address indexed user, address indexed account, uint256 amount
     );
@@ -43,7 +42,6 @@ interface IEvents {
     function emitWithdraw(address user, address account, uint256 amount)
         external;
 
-    // @inheritdoc IAccount
     event Withdraw(
         address indexed user, address indexed account, uint256 amount
     );
@@ -55,7 +53,6 @@ interface IEvents {
     function emitEthWithdraw(address user, address account, uint256 amount)
         external;
 
-    // @inheritdoc IAccount
     event EthWithdraw(
         address indexed user, address indexed account, uint256 amount
     );
@@ -82,7 +79,6 @@ interface IEvents {
         bool reduceOnly
     ) external;
 
-    // @inheritdoc IAccount
     event ConditionalOrderPlaced(
         address indexed account,
         uint256 conditionalOrderId,
@@ -105,7 +101,6 @@ interface IEvents {
         IAccount.ConditionalOrderCancelledReason reason
     ) external;
 
-    // @inheritdoc IAccount
     event ConditionalOrderCancelled(
         address indexed account,
         uint256 conditionalOrderId,
@@ -124,7 +119,6 @@ interface IEvents {
         uint256 keeperFee
     ) external;
 
-    // @inheritdoc IAccount
     event ConditionalOrderFilled(
         address indexed account,
         uint256 conditionalOrderId,
@@ -135,8 +129,9 @@ interface IEvents {
     /// @notice emitted after a fee has been transferred to Treasury
     /// @param account: the address of the account the fee was imposed on
     /// @param amount: fee amount sent to Treasury
-    function emitFeeImposed(address account, uint256 amount) external;
+    /// @param reason: reason for fee
+    function emitFeeImposed(address account, uint256 amount, bytes32 reason)
+        external;
 
-    // @inheritdoc IAccount
-    event FeeImposed(address indexed account, uint256 amount);
+    event FeeImposed(address indexed account, uint256 amount, bytes32 reason);
 }

--- a/src/interfaces/IEvents.sol
+++ b/src/interfaces/IEvents.sol
@@ -129,9 +129,16 @@ interface IEvents {
     /// @notice emitted after a fee has been transferred to Treasury
     /// @param account: the address of the account the fee was imposed on
     /// @param amount: fee amount sent to Treasury
+    /// @param marketKey: Synthetix PerpsV2 market key
     /// @param reason: reason for fee
-    function emitFeeImposed(address account, uint256 amount, bytes32 reason)
-        external;
+    function emitFeeImposed(
+        address account,
+        uint256 amount,
+        bytes32 marketKey,
+        bytes32 reason
+    ) external;
 
-    event FeeImposed(address indexed account, uint256 amount, bytes32 reason);
+    event FeeImposed(
+        address account, uint256 amount, bytes32 marketKey, bytes32 reason
+    );
 }

--- a/test/integration/margin.behavior.t.sol
+++ b/test/integration/margin.behavior.t.sol
@@ -630,7 +630,12 @@ contract MarginBehaviorTest is Test, ConsolidatedEvents {
         uint256 feeInSUSD = (price * fee) / 1e18;
 
         vm.expectEmit(true, true, true, true);
-        emit FeeImposed(address(account), feeInSUSD, bytes32("TRADE_FEE"));
+        emit FeeImposed(
+            address(account),
+            feeInSUSD,
+            sETHPERP,
+            bytes32(uint256(IAccount.FeeReason.TRADE_FEE))
+            );
         account.execute(commands, inputs);
     }
 

--- a/test/integration/margin.behavior.t.sol
+++ b/test/integration/margin.behavior.t.sol
@@ -630,7 +630,7 @@ contract MarginBehaviorTest is Test, ConsolidatedEvents {
         uint256 feeInSUSD = (price * fee) / 1e18;
 
         vm.expectEmit(true, true, true, true);
-        emit FeeImposed(address(account), feeInSUSD);
+        emit FeeImposed(address(account), feeInSUSD, bytes32("TRADE_FEE"));
         account.execute(commands, inputs);
     }
 

--- a/test/integration/order.behavior.t.sol
+++ b/test/integration/order.behavior.t.sol
@@ -53,9 +53,9 @@ contract OrderBehaviorTest is Test, ConsolidatedEvents {
         factory = setup.deploySmartMarginFactory({
             owner: address(this),
             treasury: KWENTA_TREASURY,
-            tradeFee: TRADE_FEE,
-            limitOrderFee: LIMIT_ORDER_FEE,
-            stopOrderFee: STOP_ORDER_FEE,
+            tradeFee: 0,
+            limitOrderFee: 0,
+            stopOrderFee: 0,
             addressResolver: ADDRESS_RESOLVER,
             marginAsset: MARGIN_ASSET,
             gelato: GELATO,
@@ -1072,7 +1072,8 @@ contract OrderBehaviorTest is Test, ConsolidatedEvents {
                     account: address(account),
                     conditionalOrderId: conditionalOrderId,
                     fillPrice: currentEthPriceInUSD,
-                    keeperFee: GELATO_FEE
+                    keeperFee: GELATO_FEE,
+                    kwentaFee: 0
                 });
             } else if (fuzzedSizeDelta + position.size >= 0) {
                 // expect conditional order to be filled with specified fuzzedSizeDelta
@@ -1081,7 +1082,8 @@ contract OrderBehaviorTest is Test, ConsolidatedEvents {
                     account: address(account),
                     conditionalOrderId: conditionalOrderId,
                     fillPrice: currentEthPriceInUSD,
-                    keeperFee: GELATO_FEE
+                    keeperFee: GELATO_FEE,
+                    kwentaFee: 0
                 });
             } else {
                 revert("Uncaught case");
@@ -1144,7 +1146,8 @@ contract OrderBehaviorTest is Test, ConsolidatedEvents {
                     account: address(account),
                     conditionalOrderId: conditionalOrderId,
                     fillPrice: currentEthPriceInUSD,
-                    keeperFee: GELATO_FEE
+                    keeperFee: GELATO_FEE,
+                    kwentaFee: 0
                 });
             } else if (fuzzedSizeDelta + position.size <= 0) {
                 // expect conditional order to be filled with specified fuzzedSizeDelta
@@ -1153,7 +1156,8 @@ contract OrderBehaviorTest is Test, ConsolidatedEvents {
                     account: address(account),
                     conditionalOrderId: conditionalOrderId,
                     fillPrice: currentEthPriceInUSD,
-                    keeperFee: GELATO_FEE
+                    keeperFee: GELATO_FEE,
+                    kwentaFee: 0
                 });
             } else {
                 revert("Uncaught case");

--- a/test/unit/Account.t.sol
+++ b/test/unit/Account.t.sol
@@ -239,9 +239,7 @@ contract AccountTest is Test, ConsolidatedEvents {
                              FEE UTILITIES
     //////////////////////////////////////////////////////////////*/
 
-    function test_CalculateTradeFee_EthMarket(int128 fuzzedSizeDelta)
-        external
-    {
+    function test_CalculateFee_EthMarket(int128 fuzzedSizeDelta) external {
         uint256 conditionalOrderFee = MAX_BPS / 99;
         IPerpsV2MarketConsolidated market =
             IPerpsV2MarketConsolidated(getMarketAddressFromKey(sETHPERP));
@@ -252,7 +250,7 @@ contract AccountTest is Test, ConsolidatedEvents {
         (uint256 price, bool invalid) = market.assetPrice();
         assert(!invalid);
         uint256 feeInSUSD = (price * fee) / 1e18;
-        uint256 actualFee = accountExposed.expose_calculateTradeFee({
+        uint256 actualFee = accountExposed.expose_calculateFee({
             _sizeDelta: fuzzedSizeDelta,
             _market: market,
             _conditionalOrderFee: conditionalOrderFee
@@ -260,10 +258,10 @@ contract AccountTest is Test, ConsolidatedEvents {
         assertEq(actualFee, feeInSUSD);
     }
 
-    function test_CalculateTradeFee_InvalidMarket() external {
+    function test_CalculateFee_InvalidMarket() external {
         int256 sizeDelta = -1 ether;
         vm.expectRevert();
-        accountExposed.expose_calculateTradeFee({
+        accountExposed.expose_calculateFee({
             _sizeDelta: sizeDelta,
             _market: IPerpsV2MarketConsolidated(address(0)),
             _conditionalOrderFee: LIMIT_ORDER_FEE

--- a/test/unit/Events.t.sol
+++ b/test/unit/Events.t.sol
@@ -33,9 +33,9 @@ contract EventsTest is Test, ConsolidatedEvents {
         factory = setup.deploySmartMarginFactory({
             owner: address(this),
             treasury: KWENTA_TREASURY,
-            tradeFee: TRADE_FEE,
-            limitOrderFee: LIMIT_ORDER_FEE,
-            stopOrderFee: STOP_ORDER_FEE,
+            tradeFee: 0,
+            limitOrderFee: 0,
+            stopOrderFee: 0,
             addressResolver: ADDRESS_RESOLVER,
             marginAsset: MARGIN_ASSET,
             gelato: GELATO,
@@ -175,13 +175,14 @@ contract EventsTest is Test, ConsolidatedEvents {
 
     function test_EmitConditionalOrderFilled_Event() public {
         vm.expectEmit(true, true, true, true);
-        emit ConditionalOrderFilled(ACCOUNT, 0, FILL_PRICE, GELATO_FEE);
+        emit ConditionalOrderFilled(ACCOUNT, 0, FILL_PRICE, GELATO_FEE, 0);
         vm.prank(account);
         events.emitConditionalOrderFilled({
             account: ACCOUNT,
             conditionalOrderId: 0,
             fillPrice: FILL_PRICE,
-            keeperFee: GELATO_FEE
+            keeperFee: GELATO_FEE,
+            kwentaFee: 0
         });
     }
 
@@ -191,7 +192,8 @@ contract EventsTest is Test, ConsolidatedEvents {
             account: ACCOUNT,
             conditionalOrderId: 0,
             fillPrice: FILL_PRICE,
-            keeperFee: GELATO_FEE
+            keeperFee: GELATO_FEE,
+            kwentaFee: 0
         });
     }
 

--- a/test/unit/Events.t.sol
+++ b/test/unit/Events.t.sol
@@ -197,13 +197,13 @@ contract EventsTest is Test, ConsolidatedEvents {
 
     function test_EmitFeeImposed_Event() public {
         vm.expectEmit(true, true, true, true);
-        emit FeeImposed(ACCOUNT, AMOUNT);
+        emit FeeImposed(ACCOUNT, AMOUNT, bytes32("REASON"));
         vm.prank(account);
-        events.emitFeeImposed({account: ACCOUNT, amount: AMOUNT});
+        events.emitFeeImposed({account: ACCOUNT, amount: AMOUNT, reason: bytes32("REASON")});
     }
 
     function test_EmitFeeImposed_OnlyAccounts() public {
         vm.expectRevert(abi.encodeWithSelector(IEvents.OnlyAccounts.selector));
-        events.emitFeeImposed({account: ACCOUNT, amount: AMOUNT});
+        events.emitFeeImposed({account: ACCOUNT, amount: AMOUNT, reason: bytes32("REASON")});
     }
 }

--- a/test/unit/Events.t.sol
+++ b/test/unit/Events.t.sol
@@ -199,11 +199,19 @@ contract EventsTest is Test, ConsolidatedEvents {
         vm.expectEmit(true, true, true, true);
         emit FeeImposed(ACCOUNT, AMOUNT, bytes32("REASON"));
         vm.prank(account);
-        events.emitFeeImposed({account: ACCOUNT, amount: AMOUNT, reason: bytes32("REASON")});
+        events.emitFeeImposed({
+            account: ACCOUNT,
+            amount: AMOUNT,
+            reason: bytes32("REASON")
+        });
     }
 
     function test_EmitFeeImposed_OnlyAccounts() public {
         vm.expectRevert(abi.encodeWithSelector(IEvents.OnlyAccounts.selector));
-        events.emitFeeImposed({account: ACCOUNT, amount: AMOUNT, reason: bytes32("REASON")});
+        events.emitFeeImposed({
+            account: ACCOUNT,
+            amount: AMOUNT,
+            reason: bytes32("REASON")
+        });
     }
 }

--- a/test/unit/Events.t.sol
+++ b/test/unit/Events.t.sol
@@ -197,11 +197,12 @@ contract EventsTest is Test, ConsolidatedEvents {
 
     function test_EmitFeeImposed_Event() public {
         vm.expectEmit(true, true, true, true);
-        emit FeeImposed(ACCOUNT, AMOUNT, bytes32("REASON"));
+        emit FeeImposed(ACCOUNT, AMOUNT, sETHPERP, bytes32("REASON"));
         vm.prank(account);
         events.emitFeeImposed({
             account: ACCOUNT,
             amount: AMOUNT,
+            marketKey: sETHPERP,
             reason: bytes32("REASON")
         });
     }
@@ -211,6 +212,7 @@ contract EventsTest is Test, ConsolidatedEvents {
         events.emitFeeImposed({
             account: ACCOUNT,
             amount: AMOUNT,
+            marketKey: sETHPERP,
             reason: bytes32("REASON")
         });
     }

--- a/test/utils/AccountExposed.sol
+++ b/test/utils/AccountExposed.sol
@@ -37,12 +37,12 @@ contract AccountExposed is Account {
                          EXPOSED FEE UTILITIES
     //////////////////////////////////////////////////////////////*/
 
-    function expose_calculateTradeFee(
+    function expose_calculateFee(
         int256 _sizeDelta,
         IPerpsV2MarketConsolidated _market,
         uint256 _conditionalOrderFee
     ) public view returns (uint256 fee) {
-        return _calculateTradeFee(_sizeDelta, _market, _conditionalOrderFee);
+        return _calculateFee(_sizeDelta, _market, _conditionalOrderFee);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/test/utils/ConsolidatedEvents.sol
+++ b/test/utils/ConsolidatedEvents.sol
@@ -55,7 +55,9 @@ contract ConsolidatedEvents {
         uint256 fillPrice,
         uint256 keeperFee
     );
-    event FeeImposed(address indexed account, uint256 amount, bytes32 reason);
+    event FeeImposed(
+        address account, uint256 amount, bytes32 marketKey, bytes32 reason
+    );
 
     /*//////////////////////////////////////////////////////////////
                                 IFACTORY

--- a/test/utils/ConsolidatedEvents.sol
+++ b/test/utils/ConsolidatedEvents.sol
@@ -53,7 +53,8 @@ contract ConsolidatedEvents {
         address indexed account,
         uint256 conditionalOrderId,
         uint256 fillPrice,
-        uint256 keeperFee
+        uint256 keeperFee,
+        uint kwentaFee
     );
     event FeeImposed(
         address account, uint256 amount, bytes32 marketKey, bytes32 reason

--- a/test/utils/ConsolidatedEvents.sol
+++ b/test/utils/ConsolidatedEvents.sol
@@ -55,7 +55,7 @@ contract ConsolidatedEvents {
         uint256 fillPrice,
         uint256 keeperFee
     );
-    event FeeImposed(address indexed account, uint256 amount);
+    event FeeImposed(address indexed account, uint256 amount, bytes32 reason);
 
     /*//////////////////////////////////////////////////////////////
                                 IFACTORY


### PR DESCRIPTION
Improve fee related events:
`event FeeImposed(address indexed account, uint256 amount, bytes32 market, bytes32 reason);`

## Description
* Update `FeeImposed` event to include a `reason`
* Update `FeeImposed` event to include a `market`
* Update tests for new events

## Related issue(s)
Closes https://github.com/Kwenta/margin-manager/issues/96

## Motivation and Context
SMv2.0.0