### PR TITLE
test: account removed from old factory ownership list

### DIFF
--- a/test/unit/Account.t.sol
+++ b/test/unit/Account.t.sol
@@ -166,24 +166,27 @@ contract AccountTest is Test, ConsolidatedEvents {
 
     function test_Ownership_Transfer() public {
         // ensure factory and account state align
-        address currentOwner = factory.getAccountOwner(address(account));
+        address originalOwner = factory.getAccountOwner(address(account));
         assert(
-            currentOwner == address(this) && currentOwner == account.owner()
-                && currentOwner != KWENTA_TREASURY
+            originalOwner == address(this) && originalOwner == account.owner()
+                && originalOwner != KWENTA_TREASURY
         );
-        assert(factory.getAccountsOwnedBy(currentOwner)[0] == address(account));
+        assert(factory.getAccountsOwnedBy(originalOwner)[0] == address(account));
 
         // transfer ownership
         account.transferOwnership(KWENTA_TREASURY);
         assert(account.owner() == KWENTA_TREASURY);
 
         // ensure factory and account state align
-        currentOwner = factory.getAccountOwner(address(account));
+        address newOwner = factory.getAccountOwner(address(account));
         assert(
-            currentOwner == KWENTA_TREASURY && currentOwner == account.owner()
+            newOwner == KWENTA_TREASURY && newOwner == account.owner()
         );
         assert(
             factory.getAccountsOwnedBy(KWENTA_TREASURY)[0] == address(account)
+        );
+        assert(
+            factory.getAccountsOwnedBy(originalOwner).length == 0
         );
     }
 


### PR DESCRIPTION
Was just testing for bugs and found something that is secure but untested. This adds the test.

It just extends the test_Ownership_Transfer test to ensure that not only is the account added to the new owners list but also removed from the old one.