### PR TITLE
📚 Update docs

### DIFF
--- a/src/Account.sol
+++ b/src/Account.sol
@@ -909,7 +909,7 @@ contract Account is IAccount, Auth, OpsReady {
 
     /// @notice fetch PerpsV2Market market defined by market key
     /// @param _marketKey: key for Synthetix PerpsV2 market
-    /// @return IPerpsV2Market contract interface
+    /// @return IPerpsV2MarketConsolidated contract interface
     function _getPerpsV2Market(bytes32 _marketKey)
         internal
         view

--- a/src/interfaces/IFactory.sol
+++ b/src/interfaces/IFactory.sol
@@ -11,6 +11,7 @@ interface IFactory {
     /// @notice emitted when new account is created
     /// @param creator: account creator (address that called newAccount())
     /// @param account: address of account that was created (will be address of proxy)
+    /// @param version: version of account created
     event NewAccount(
         address indexed creator, address indexed account, bytes32 version
     );


### PR DESCRIPTION
## [Q-8] Documentation improvements

- In IFactory.sol, natspec is missing for the version param of the `NewAccount` event.
- In Account.sol, natspec for the return value of `_getPerpsV2Market()` indicates IPerpsV2Market type. However, the return value is of type `IPerpsV2MarketConsolidated`.