### PR TITLE
📣 Add indexed attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ npm run compile
 npm run test
 ```
 
+4. Run specific test
+
+```
+forge test --fork-url $(grep ARCHIVE_NODE_URL_GOERLI_L2 .env | cut -d '=' -f2) --match-test TEST_NAME -vvv
+```
+
 > tests will fail if you have not set up your .env (see .env.example)
 
 ### Upgradability

--- a/src/interfaces/IEvents.sol
+++ b/src/interfaces/IEvents.sol
@@ -73,7 +73,7 @@ interface IEvents {
 
     event ConditionalOrderPlaced(
         address indexed account,
-        uint256 conditionalOrderId,
+        uint256 indexed conditionalOrderId,
         bytes32 marketKey,
         int256 marginDelta,
         int256 sizeDelta,
@@ -93,7 +93,7 @@ interface IEvents {
 
     event ConditionalOrderCancelled(
         address indexed account,
-        uint256 conditionalOrderId,
+        uint256 indexed conditionalOrderId,
         IAccount.ConditionalOrderCancelledReason reason
     );
 
@@ -109,7 +109,7 @@ interface IEvents {
 
     event ConditionalOrderFilled(
         address indexed account,
-        uint256 conditionalOrderId,
+        uint256 indexed conditionalOrderId,
         uint256 fillPrice,
         uint256 keeperFee
     );

--- a/test/utils/ConsolidatedEvents.sol
+++ b/test/utils/ConsolidatedEvents.sol
@@ -50,7 +50,7 @@ contract ConsolidatedEvents {
 
     event ConditionalOrderPlaced(
         address indexed account,
-        uint256 conditionalOrderId,
+        uint256 indexed conditionalOrderId,
         bytes32 marketKey,
         int256 marginDelta,
         int256 sizeDelta,
@@ -62,13 +62,13 @@ contract ConsolidatedEvents {
 
     event ConditionalOrderCancelled(
         address indexed account,
-        uint256 conditionalOrderId,
+        uint256 indexed conditionalOrderId,
         IAccount.ConditionalOrderCancelledReason reason
     );
 
     event ConditionalOrderFilled(
         address indexed account,
-        uint256 conditionalOrderId,
+        uint256 indexed conditionalOrderId,
         uint256 fillPrice,
         uint256 keeperFee
     );


### PR DESCRIPTION
## [Q-7] Missing indexed attribute for conditional order events

For events, `ConditionalOrderPlaced`, `ConditionalOrderCancelled`, and `ConditionalOrderFilled` consider making the `conditionalOrderId` parameter indexed to facilitate off-chain monitoring and tracking.